### PR TITLE
typing에 따른 대체어 제안 기능 구현

### DIFF
--- a/app/src/main/java/com/example/friendlykeyboard/SplashActivity.kt
+++ b/app/src/main/java/com/example/friendlykeyboard/SplashActivity.kt
@@ -14,9 +14,12 @@ class SplashActivity : AppCompatActivity() {
         binding = ActivitySplashBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        Handler().postDelayed({
-            startActivity(Intent(this, LoginActivity::class.java))
-            finish()
-        }, 2000)
+        startActivity(Intent(this, LoginActivity::class.java))
+        finish()
+
+//        Handler().postDelayed({
+//            startActivity(Intent(this, LoginActivity::class.java))
+//            finish()
+//        }, 2000)
     }
 }

--- a/app/src/main/java/com/example/friendlykeyboard/keyboard/CandidateView.kt
+++ b/app/src/main/java/com/example/friendlykeyboard/keyboard/CandidateView.kt
@@ -54,9 +54,9 @@ class CandidateView(context: Context, layoutInflater: LayoutInflater) : View(con
 
             }
         }
-        else{
-            mCandidateLL.removeAllViews()
-        }
+//        else{
+//            mCandidateLL.removeAllViews()
+//        }
 
     }
 
@@ -64,6 +64,13 @@ class CandidateView(context: Context, layoutInflater: LayoutInflater) : View(con
         mSuggestion.put("ㅁㅊ", arrayListOf<String>("와", "대박", "헐"))
         mSuggestion.put("ㅅㄲ야", arrayListOf<String>("친구야", "자식아", "얘야"))
         mSuggestion.put("ㅈㄴ", arrayListOf<String>("매우", "정말", "완전"))
+        mSuggestion.put("콘텐츠", arrayListOf<String>("제작물"))
+        mSuggestion.put("오리지널 콘텐츠", arrayListOf<String>("자체 제작물"))
+        mSuggestion.put("멀티데믹", arrayListOf<String>("감염병 복합 유행"))
+        mSuggestion.put("노마드 워커", arrayListOf<String>("유목민형 노동자"))
+        mSuggestion.put("디지털 트윈", arrayListOf<String>("가상 모형"))
+        mSuggestion.put("커리어 하이", arrayListOf<String>("최고 기록"))
+        mSuggestion.put("주스 주스", arrayListOf<String>("쥬시쿨"))
     }
 
     // 추후 설정 관련
@@ -74,6 +81,9 @@ class CandidateView(context: Context, layoutInflater: LayoutInflater) : View(con
         mCandidateHSV.setBackgroundColor(Color.parseColor(mColorBackground))
     }
 
+    fun eraseViews(){
+        mCandidateLL.removeAllViews()
+    }
 
     fun getCandidate() : HorizontalScrollView{
         return mCandidateHSV

--- a/app/src/main/java/com/example/friendlykeyboard/keyboard/keyboardview/KeyboardEnglish.kt
+++ b/app/src/main/java/com/example/friendlykeyboard/keyboard/keyboardview/KeyboardEnglish.kt
@@ -382,6 +382,8 @@ class KeyboardEnglish constructor(var context: Context, var layoutInflater: Layo
             playClick('ㅂ'.toInt())
             playVibrate()
             inputConnection?.commitText(" ",1)
+            //space바 눌렀을 때 잔존 candidateView 지우기 위함
+            keyboardInterationListener.sendText("")
         }
     }
 

--- a/app/src/main/java/com/example/friendlykeyboard/keyboard/keyboardview/KeyboardKorean.kt
+++ b/app/src/main/java/com/example/friendlykeyboard/keyboard/keyboardview/KeyboardKorean.kt
@@ -366,6 +366,8 @@ class KeyboardKorean constructor(var context:Context, var layoutInflater: Layout
             playClick('ㅂ'.toInt())
             playVibrate()
             hangulMaker.commitSpace()
+            //space바 눌렀을 때 잔존 candidateView 지우기 위함
+            keyboardInterationListener.sendText("")
         }
     }
 


### PR DESCRIPTION
- 커서 위치 변경에 불문하고 typing 시 현재 커서 위치 기준 어절 단위로 양방향으로 어절들을 추가 및 검색하여 존재하는 대체어를 제안합니다. ex '오리지널 콘츠' -> '오리지널 콘텐츠' 인식 후 제안 ('자체 제작물')

- 어절 단위기 때문에 문장 수정 중 양방향 낱말 기준 조합이 사전(대체어 딕셔너리)에 존재하여도 인식하지는 못합니다. ex '오리지 콘텐츠를' -> '오리지널 콘텐츠를' 인식 불가

- 더 빠른 테스트 환경을 위해 splashActivity를 잠시 비활성화 했습니다

- 양방향으로 검색하기 때문에 첫 어절 중복 탐색 --> 수정 필요

- 대체어 제안 클릭 시 replaceText 기능 구현 필요